### PR TITLE
common/lru: fix race in lru (#26164)

### DIFF
--- a/common/lru/blob_lru.go
+++ b/common/lru/blob_lru.go
@@ -33,7 +33,7 @@ type SizeConstrainedLRU struct {
 	size    uint64
 	maxSize uint64
 	lru     *simplelru.LRU
-	lock    sync.RWMutex
+	lock    sync.Mutex
 }
 
 // NewSizeConstrainedLRU creates a new SizeConstrainedLRU.
@@ -78,8 +78,8 @@ func (c *SizeConstrainedLRU) Add(key common.Hash, value []byte) (evicted bool) {
 
 // Get looks up a key's value from the cache.
 func (c *SizeConstrainedLRU) Get(key common.Hash) []byte {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 
 	if v, ok := c.lru.Get(key); ok {
 		return v.([]byte)


### PR DESCRIPTION
This fixes a problem in the SizeConstrainedLRU. The SCLRU uses an underlying simple lru which is not thread safe. During the Get operation, the recentness of the accessed item is updated, so it is not a pure read-operation. Therefore, the mutex we need is a full mutex, not RLock.

This PR changes the mutex to be a regular Mutex, instead of RWMutex, so a reviewer can at a glance see that all affected locations are fixed.

(cherry picked from commit 8334b5f51a16b72cf2b3ebdc9e131a442c5289d7)