### PR TITLE
 Fix: blockhash mismatch when calling "amana.propose(addr, true)"

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -77,6 +77,7 @@ type ExecutableData struct {
 	BlobGasUsed   *uint64             `json:"blobGasUsed"`
 	ExcessBlobGas *uint64             `json:"excessBlobGas"`
 	Difficulty    *big.Int            `json:"difficulty"`
+	Nonce         types.BlockNonce    `json:"nonce"`
 }
 
 // JSON type overrides for executableData.


### PR DESCRIPTION
When authorizing a new sealer node using `amana.propose(addr, true)`, we receive a `blockhash mismatch` error with the existing node unable to seal any new blocks (unless you restart the node). 

This is because in the block header, the nonce field needs to be set to `0xffffffffffffffff` to authorize an address but, by default, this is set to `0x0`.